### PR TITLE
Convert from "java" (deprecated as of 2016-12-31) to "openjdk"

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -1,5 +1,5 @@
 # Set the base image
-FROM java:openjdk-8-jre
+FROM openjdk:8-jre
 
 MAINTAINER Lightstreamer Server Development Team <support@lightreamer.com>
 


### PR DESCRIPTION
See https://github.com/docker-library/docs/pull/660/files#diff-5b18106a0a6d9cd97a6ecf2793c3347e (https://hub.docker.com/_/java/).