### PR TITLE
Complete the OS-variant removal refactor

### DIFF
--- a/Dockerfile-base.template
+++ b/Dockerfile-base.template
@@ -38,7 +38,7 @@ ${LEGACY_PATCH}# Strip content that downstream images are expected to provide th
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME"
 
-FROM eclipse-temurin:${JAVA_VERSION}-${FLAVOR}-${OS_VARIANT}
+FROM eclipse-temurin:${JAVA_VERSION}-${FLAVOR}
 LABEL maintainer="Lightstreamer Server Development Team <support@lightstreamer.com>"
 ENV LIGHTSTREAMER_VERSION=${LIGHTSTREAMER_VERSION}
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -33,7 +33,7 @@ ${LEGACY_PATCH}# Adjust the logging configuration in order to log only on standa
         && gpgconf --kill all \
         && rm -rf "$GNUPGHOME"
 
-FROM eclipse-temurin:${JAVA_VERSION}-${FLAVOR}-${OS_VARIANT}
+FROM eclipse-temurin:${JAVA_VERSION}-${FLAVOR}
 LABEL maintainer="Lightstreamer Server Development Team <support@lightstreamer.com>"
 ENV LIGHTSTREAMER_VERSION=${LIGHTSTREAMER_VERSION}
 

--- a/docs/making-changes.md
+++ b/docs/making-changes.md
@@ -5,15 +5,15 @@ This document is for anyone modifying the Lightstreamer Docker images — whethe
 ## How the repository is organised
 
 ```
-├── versions.json                     ← Source of truth for versions × runtimes × OS × variants
+├── versions.json                     ← Source of truth for versions × runtimes × variants
 ├── Dockerfile.template               ← Template for the "full" edition
 ├── Dockerfile-base.template          ← Template for the "base" edition
 ├── update.sh                         ← Regenerates the Dockerfile tree from versions.json
 ├── generate-stackbrew-library.sh     ← Regenerates the `lightstreamer` manifest
 ├── lightstreamer                     ← DOI manifest (generated; committed for review)
 │
-├── <major.minor>/<runtime><java>/temurin-<os>/Dockerfile        ← generated
-├── <major.minor>/<runtime><java>/temurin-<os>-base/Dockerfile   ← generated
+├── <major.minor>/<runtime><java>/Dockerfile         ← generated (full edition)
+├── <major.minor>/<runtime><java>-base/Dockerfile    ← generated (base edition)
 │
 ├── test/
 │   ├── lint.sh                       ← Layer 1: shellcheck, JSON schema, hadolint
@@ -32,12 +32,12 @@ flowchart LR
     A[versions.json] --> U[update.sh]
     T1[Dockerfile.template] --> U
     T2[Dockerfile-base.template] --> U
-    U --> D[Generated Dockerfiles<br/>mm/runtime+java/temurin-os/*]
+    U --> D[Generated Dockerfiles<br/>mm/runtime+java/*]
     D --> G[generate-stackbrew-library.sh]
     G --> L[lightstreamer<br/>DOI manifest]
 ```
 
-- **`update.sh`** iterates every `(version × runtime × java × os × variant)` combination in `versions.json`, feeds each through the appropriate template via `envsubst`, and writes one Dockerfile per combination.
+- **`update.sh`** iterates every `(version × runtime × java × variant)` combination in `versions.json`, feeds each through the appropriate template via `envsubst`, and writes one Dockerfile per combination.
 - **`generate-stackbrew-library.sh`** walks the generated tree, looks up patch versions from `versions.json`, and emits the DOI-format `lightstreamer` file with the tag list and git commit hashes.
 - **`lightstreamer`** is committed to the repo as a golden reference — the regression test compares fresh generator output against it, so any unintentional tag change surfaces in the PR diff.
 
@@ -74,8 +74,7 @@ Most frequent change. Edit exactly one line in `versions.json`:
 ```json
 "7.4": {
     "version": "7.4.9",                     ← change this
-    "runtimes": { "jdk": ["8", "11", "17", "21", "25"] },
-    "os": ["jammy", "noble"]
+    "runtimes": { "jdk": ["8", "11", "17", "21", "25"] }
 }
 ```
 
@@ -97,49 +96,31 @@ Add the version to `runtimes.jdk` for the affected `major.minor`:
 ```json
 "7.4": {
     "version": "7.4.9",
-    "runtimes": { "jdk": ["8", "11", "17", "21", "25", "26"] },
-    "os": ["jammy", "noble"]
+    "runtimes": { "jdk": ["8", "11", "17", "21", "25", "26"] }
 }
 ```
 
 Then:
 
 ```bash
-./update.sh                            # creates new 7.4/jdk26/temurin-*/ dirs
+./update.sh                            # creates new 7.4/jdk26[-base]/ dirs
 ./generate-stackbrew-library.sh > lightstreamer
 ./test/lint.sh && ./test/regression.sh
-git add versions.json 7.4/jdk26/ lightstreamer
+git add versions.json 7.4/jdk26 7.4/jdk26-base lightstreamer
 git commit -m "Add Java 26 support to 7.4"
 git push
 ```
 
 If Java 26 should become the new canonical/default (the one that gets bare tags like `7.4`, `latest`, `7`), also update `default_java` at the top of [`generate-stackbrew-library.sh`](../generate-stackbrew-library.sh) and regenerate.
 
-### 3. Add or remove an OS (e.g. drop `jammy`)
-
-Edit the `os` array for the affected version(s):
-
-```json
-"7.4": {
-    "version": "7.4.9",
-    "runtimes": { "jdk": [...] },
-    "os": ["noble"]                    ← removed "jammy"
-}
-```
-
-`./update.sh`'s atomic swap removes any leftover directories that no longer appear in the manifest.
-
-If the removed OS was the canonical one (`default_os` in `generate-stackbrew-library.sh`), pick a new default too.
-
-### 4. Add a new Lightstreamer major/minor (e.g. 7.5)
+### 3. Add a new Lightstreamer major/minor (e.g. 7.5)
 
 Add a new object under `.versions`:
 
 ```json
 "7.5": {
     "version": "7.5.0",
-    "runtimes": { "jdk": ["11", "17", "21", "25"] },
-    "os": ["noble"]
+    "runtimes": { "jdk": ["11", "17", "21", "25"] }
 }
 ```
 
@@ -148,7 +129,7 @@ Then regenerate. Note:
 - The **overall latest** (the version that earns `latest`/`<major>` tags) is determined by the LAST key in `.versions`. Put newer versions later.
 - If it's a new major (e.g. `8.0`), the `<major>-…` tag for `8` will move to it automatically.
 
-### 5. Modify a Dockerfile template
+### 4. Modify a Dockerfile template
 
 Edit `Dockerfile.template` (full edition) or `Dockerfile-base.template` (base edition). Then:
 
@@ -162,7 +143,7 @@ Edit `Dockerfile.template` (full edition) or `Dockerfile-base.template` (base ed
 
 The `build-and-run.sh` step is slow (10–30 min) but it's the only way to catch template bugs that only surface at `docker build` time — a broken template renders to a syntactically-fine Dockerfile that fails when Docker tries to execute it.
 
-### 6. Change tag naming rules
+### 5. Change tag naming rules
 
 Tag rules live inside the main loop of [`generate-stackbrew-library.sh`](../generate-stackbrew-library.sh) — read the inline comments there before editing.
 
@@ -221,14 +202,13 @@ Before running the [Workflow](#workflow) below, decide the PR title — you'll u
 | Routine patch bump | `lightstreamer: 7.4.10` |
 | Add a new Java version | `lightstreamer: add jdk26` |
 | Add a new major/minor | `lightstreamer: 7.5.0` |
-| Drop an OS | `lightstreamer: drop jammy` |
 | Structural change (tag scheme, new variant family, etc.) | `lightstreamer: refactor tag scheme; add -base variant` |
 
 Rules of thumb:
 
 - **State the *change*, not the motivation.** `refactor tag scheme` ✅, not `improve tag discoverability` ❌.
 - **Use a semicolon for two conceptually distinct changes** in one PR. Reviewers know to check each independently.
-- **Omit consequences** (OS pin, dependency bumps triggered by the change, etc.) — the body explains them. Keeps the title stable if the body evolves during review.
+- **Omit consequences** (dependency bumps triggered by the change, etc.) — the body explains them. Keeps the title stable if the body evolves during review.
 - **Reuse DOI's own vocabulary** where it exists — "refactor tag scheme", "add variant", "add architecture", "deprecate" — so the title sets the correct reviewer mental model.
 
 ### Workflow

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -11,12 +11,11 @@ maintainer=$'Lightstreamer Server Development Team <support@lightstreamer.com> (
 gitrepo="https://github.com/Lightstreamer/Docker.git"
 
 # --- Canonical combination that earns the short/bare tags -------------------
-# The image whose (flavor, java, os, variant) matches these four values
-# receives `latest`/`<major>`/bare-`<mm>`/bare-`<patch>` (or `-<variant>`
-# versions of those, when variant != default_variant).
+# The image whose (flavor, java, variant) matches these three values receives
+# `latest`/`<major>`/bare-`<mm>`/bare-`<patch>` (or `-<variant>` versions of
+# those, when variant != default_variant).
 default_flavor="jdk"
 default_java="25"
-default_os="noble"
 default_variant="full"
 
 # Patch version per "major.minor", plus the ordered list of keys (oldest -> newest).
@@ -38,41 +37,39 @@ for mm in "${mm_list[@]}"; do
 done
 overall_latest_mm="${mm_list[-1]}"
 
-# Per-version canonical variant: the (flavor, java, os) triple that this
+# Per-version canonical combination: the (flavor, java) pair that this
 # version's bare tags (patch, mm, and — when this is the latest minor of its
 # major — major) point to. Preferences fall back gracefully:
 #   flavor: default_flavor if this version supports it, else its first flavor
 #   java:   default_java if that flavor supports it, else its highest java
-#   os:     default_os if this version supports it, else its first os
 # This lets older versions (that don't ship the global-default Java) still
 # earn bare tags like `7.3.3`, `7.3`, `6`, etc.
 declare -A canonical_flavor_of=()
 declare -A canonical_java_of=()
-declare -A canonical_os_of=()
-while read -r mm cflavor cjava cos; do
+while read -r mm cflavor cjava; do
     canonical_flavor_of[$mm]="$cflavor"
     canonical_java_of[$mm]="$cjava"
-    canonical_os_of[$mm]="$cos"
 done < <(jq -r \
     --arg df "$default_flavor" \
-    --arg dj "$default_java" \
-    --arg dos "$default_os" '
+    --arg dj "$default_java" '
     .versions | to_entries[]
     | .key as $mm
     | .value.runtimes as $rt
-    | .value.os as $oss
     | (if $rt | has($df) then $df else ($rt | keys_unsorted[0]) end) as $cf
     | $rt[$cf] as $javas
     | (if ($javas | index($dj)) then $dj else ($javas | map(tonumber) | max | tostring) end) as $cj
-    | (if ($oss | index($dos)) then $dos else $oss[0] end) as $co
-    | "\($mm) \($cf) \($cj) \($co)"
+    | "\($mm) \($cf) \($cj)"
 ' versions.json)
 # -----------------------------------------------------------------------------
 
-# All Dockerfiles under <mm>/<flavor><java>/temurin-<os>/Dockerfile.
+# All Dockerfiles under <mm>/<flavor><java>[-<variant>]/Dockerfile. The glob
+# returns them in lexicographic order (jdk11 < jdk17 < ... < jdk25 < jdk8),
+# which is wrong: `sort -V` gives numeric-aware order — jdk8 before jdk11,
+# and a "-base" sibling right after its default-variant counterpart.
 shopt -s nullglob
-image_dirs=( [0-9]*/*/temurin-*/Dockerfile )
+image_dirs=( [0-9]*/*/Dockerfile )
 image_dirs=( "${image_dirs[@]%/Dockerfile}" )
+mapfile -t image_dirs < <(printf '%s\n' "${image_dirs[@]}" | sort -V)
 
 join_by() {
     # Join args 2..N with the multi-char separator in $1.
@@ -87,21 +84,19 @@ architecture="amd64, arm64v8"
 
 for dir in "${image_dirs[@]}"; do
     # --- Parse the directory path ------------------------------------------
-    # Full variant: 7.4/jdk25/temurin-noble         → variant=full
-    # Base variant: 7.4/jdk25/temurin-noble-base    → variant=base
-    IFS='/' read -r mm flavor_java temurin_os <<<"$dir"
-    flavor="${flavor_java%%[0-9]*}"          # jdk | jre
-    java="${flavor_java#$flavor}"            # 17 | 21 | 25
-    os_and_variant="${temurin_os#temurin-}"  # jammy | noble | jammy-base | noble-base
-    if [[ "$os_and_variant" == *-base ]]; then
+    # Full variant: 7.4/jdk25         → variant=full
+    # Base variant: 7.4/jdk25-base    → variant=base
+    IFS='/' read -r mm flavor_java_variant <<<"$dir"
+    if [[ "$flavor_java_variant" == *-base ]]; then
         variant="base"
-        os="${os_and_variant%-base}"
+        flavor_java="${flavor_java_variant%-base}"
     else
         variant="full"
-        os="$os_and_variant"
+        flavor_java="$flavor_java_variant"
     fi
+    flavor="${flavor_java%%[0-9]*}"          # jdk | jre
+    java="${flavor_java#$flavor}"            # 17 | 21 | 25
     major="${mm%%.*}"
-    suffix="${flavor}${java}-temurin-${os}"
 
     # --- Look up patch version (from versions.json, not the Dockerfile) ---
     patch="${patch_of[$mm]:-}"
@@ -116,52 +111,47 @@ for dir in "${image_dirs[@]}"; do
     # --- Classify this image (1 = yes, 0 = no) ---
     is_latest_minor=0;    [[ "${latest_minor_per_major[$major]}" == "$mm" ]] && is_latest_minor=1
     is_overall_latest=0;  [[ "$mm" == "$overall_latest_mm" ]]               && is_overall_latest=1
-    # Canonical = the (flavor, java, os) this version's bare tags point to.
+    # Canonical = the (flavor, java) this version's bare tags point to.
     is_canonical=0
-    [[ "$flavor$java$os" == "${canonical_flavor_of[$mm]}${canonical_java_of[$mm]}${canonical_os_of[$mm]}" ]] \
+    [[ "$flavor$java" == "${canonical_flavor_of[$mm]}${canonical_java_of[$mm]}" ]] \
         && is_canonical=1
-    # OS-canonical = same version's canonical OS, regardless of flavor/java.
-    # Drives the "no-OS" short tags like 7.4.8-jdk11, 7-jre25, etc.
-    is_canonical_os=0
-    [[ "$os" == "${canonical_os_of[$mm]}" ]] && is_canonical_os=1
     is_default_variant=0; [[ "$variant" == "$default_variant" ]] && is_default_variant=1
 
     # --- Build the tag list -------------------------------------------------
-    # A "-<variant>" suffix is appended to every non-default-variant tag.
-    # For the default variant (full) the tags look exactly like they did before.
+    # A "-<variant>" suffix is appended to every non-default-variant tag; the
+    # default variant (full) gets an empty suffix.
     if (( is_default_variant )); then
-        vsuf=""       # e.g. "7.4.8-jdk25-temurin-noble"
-        vbare=""      # e.g. "7.4.8", "latest"
+        vsuf=""       # e.g. "7.4.8-jdk25"
     else
-        vsuf="-${variant}"      # e.g. "7.4.8-jdk25-temurin-noble-base"
-        vbare="-${variant}"     # e.g. "7.4.8-base", "base"
+        vsuf="-${variant}"      # e.g. "7.4.8-jdk25-base"
     fi
 
-    tags=( "${patch}-${suffix}${vsuf}" "${mm}-${suffix}${vsuf}" )
-    (( is_latest_minor ))                   && tags+=( "${major}-${suffix}${vsuf}" )
-    # Short "no-OS" tags: <ver>-<flavor><java>[-<variant>], one per version level,
-    # emitted for images on the canonical OS of their version. Also emits the
-    # `-temurin` (no-OS) suffix form for backwards compatibility with the
-    # currently-published DOI manifest, which used those before the OS became
-    # part of the tag.
-    if (( is_canonical_os )); then
-        tags+=( "${patch}-${flavor}${java}${vbare}" "${mm}-${flavor}${java}${vbare}" )
-        (( is_latest_minor )) && tags+=( "${major}-${flavor}${java}${vbare}" )
-        tags+=( "${patch}-${flavor}${java}-temurin${vbare}" "${mm}-${flavor}${java}-temurin${vbare}" )
-        (( is_latest_minor )) && tags+=( "${major}-${flavor}${java}-temurin${vbare}" )
+    # Primary (flavor+java) tags, plus a "-temurin" mirror kept for
+    # backwards compatibility with the previously-published DOI manifest.
+    tags=(
+        "${patch}-${flavor}${java}${vsuf}"          "${mm}-${flavor}${java}${vsuf}"
+        "${patch}-${flavor}${java}-temurin${vsuf}"  "${mm}-${flavor}${java}-temurin${vsuf}"
+    )
+    if (( is_latest_minor )); then
+        tags+=(
+            "${major}-${flavor}${java}${vsuf}"
+            "${major}-${flavor}${java}-temurin${vsuf}"
+        )
     fi
-    (( is_canonical ))                      && tags+=( "${patch}${vbare}" "${mm}${vbare}" )
-    (( is_canonical && is_latest_minor ))   && tags+=( "${major}${vbare}" )
+    # Bare tags (no flavor/java suffix) — only for the canonical (flavor,java)
+    # of this mm.
+    (( is_canonical ))                      && tags+=( "${patch}${vsuf}" "${mm}${vsuf}" )
+    (( is_canonical && is_latest_minor ))   && tags+=( "${major}${vsuf}" )
     (( is_canonical && is_overall_latest )) && tags+=( "$( (( is_default_variant )) && echo latest || echo "${variant}" )" )
 
     # Example output block (full-variant, canonical image on 7.4):
-    #   Tags: 7.4.8-jdk25-temurin-noble, 7.4-jdk25-temurin-noble, 7-jdk25-temurin-noble,
-    #         7.4.8-jdk25, 7.4-jdk25, 7-jdk25,
-    #         7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25-temurin,
+    #   Tags: 7.4.8-jdk25, 7.4-jdk25,
+    #         7.4.8-jdk25-temurin, 7.4-jdk25-temurin,
+    #         7-jdk25, 7-jdk25-temurin,
     #         7.4.8, 7.4, 7, latest
     #   Architectures: amd64, arm64v8
     #   GitCommit: 156c40…
-    #   Directory: 7.4/jdk25/temurin-noble
+    #   Directory: 7.4/jdk25
     printf '\nTags: %s\nArchitectures: %s\nGitCommit: %s\nDirectory: %s\n' \
         "$(join_by ', ' "${tags[@]}")" "$architecture" "$commit" "$dir"
 done

--- a/lightstreamer
+++ b/lightstreamer
@@ -3,322 +3,162 @@ Maintainers: Lightstreamer Server Development Team <support@lightstreamer.com> (
              Gianluca Finocchiaro <gianluca.finocchiaro@lightstreamer.com> (@gfinocchiaro)
 GitRepo: https://github.com/Lightstreamer/Docker.git
 
-Tags: 6.0.3-jdk8-temurin-jammy-base, 6.0-jdk8-temurin-jammy-base
+Tags: 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.0/jdk8
 
-Tags: 6.0.3-jdk8-temurin-jammy, 6.0-jdk8-temurin-jammy
+Tags: 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.0/jdk8-base
 
-Tags: 6.0.3-jdk8-temurin-noble-base, 6.0-jdk8-temurin-noble-base, 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
+Tags: 6.1.0-jdk8, 6.1-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8, 6-jdk8-temurin, 6.1.0, 6.1, 6
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.1/jdk8
 
-Tags: 6.0.3-jdk8-temurin-noble, 6.0-jdk8-temurin-noble, 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
+Tags: 6.1.0-jdk8-base, 6.1-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.1/jdk8-base
 
-Tags: 6.1.0-jdk8-temurin-jammy-base, 6.1-jdk8-temurin-jammy-base, 6-jdk8-temurin-jammy-base
+Tags: 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk8
 
-Tags: 6.1.0-jdk8-temurin-jammy, 6.1-jdk8-temurin-jammy, 6-jdk8-temurin-jammy
+Tags: 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk8-base
 
-Tags: 6.1.0-jdk8-temurin-noble-base, 6.1-jdk8-temurin-noble-base, 6-jdk8-temurin-noble-base, 6.1.0-jdk8-base, 6.1-jdk8-base, 6-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
+Tags: 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk11
 
-Tags: 6.1.0-jdk8-temurin-noble, 6.1-jdk8-temurin-noble, 6-jdk8-temurin-noble, 6.1.0-jdk8, 6.1-jdk8, 6-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8-temurin, 6.1.0, 6.1, 6
+Tags: 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk11-base
 
-Tags: 7.0.3-jdk11-temurin-jammy-base, 7.0-jdk11-temurin-jammy-base
+Tags: 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk8
 
-Tags: 7.0.3-jdk11-temurin-jammy, 7.0-jdk11-temurin-jammy
+Tags: 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk8-base
 
-Tags: 7.0.3-jdk11-temurin-noble-base, 7.0-jdk11-temurin-noble-base, 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
+Tags: 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk11
 
-Tags: 7.0.3-jdk11-temurin-noble, 7.0-jdk11-temurin-noble, 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
+Tags: 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk11-base
 
-Tags: 7.0.3-jdk8-temurin-jammy-base, 7.0-jdk8-temurin-jammy-base
+Tags: 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk8
 
-Tags: 7.0.3-jdk8-temurin-jammy, 7.0-jdk8-temurin-jammy
+Tags: 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk8-base
 
-Tags: 7.0.3-jdk8-temurin-noble-base, 7.0-jdk8-temurin-noble-base, 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
+Tags: 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk11
 
-Tags: 7.0.3-jdk8-temurin-noble, 7.0-jdk8-temurin-noble, 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
+Tags: 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk11-base
 
-Tags: 7.1.3-jdk11-temurin-jammy-base, 7.1-jdk11-temurin-jammy-base
+Tags: 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk8
 
-Tags: 7.1.3-jdk11-temurin-jammy, 7.1-jdk11-temurin-jammy
+Tags: 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk8-base
 
-Tags: 7.1.3-jdk11-temurin-noble-base, 7.1-jdk11-temurin-noble-base, 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
+Tags: 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk11
 
-Tags: 7.1.3-jdk11-temurin-noble, 7.1-jdk11-temurin-noble, 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
+Tags: 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk11-base
 
-Tags: 7.1.3-jdk8-temurin-jammy-base, 7.1-jdk8-temurin-jammy-base
+Tags: 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk17
 
-Tags: 7.1.3-jdk8-temurin-jammy, 7.1-jdk8-temurin-jammy
+Tags: 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk17-base
 
-Tags: 7.1.3-jdk8-temurin-noble-base, 7.1-jdk8-temurin-noble-base, 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
+Tags: 7.4.8-jdk8, 7.4-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8, 7-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk8
 
-Tags: 7.1.3-jdk8-temurin-noble, 7.1-jdk8-temurin-noble, 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
+Tags: 7.4.8-jdk8-base, 7.4-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-base, 7-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk8-base
 
-Tags: 7.2.2-jdk11-temurin-jammy-base, 7.2-jdk11-temurin-jammy-base
+Tags: 7.4.8-jdk11, 7.4-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11, 7-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk11
 
-Tags: 7.2.2-jdk11-temurin-jammy, 7.2-jdk11-temurin-jammy
+Tags: 7.4.8-jdk11-base, 7.4-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-base, 7-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk11-base
 
-Tags: 7.2.2-jdk11-temurin-noble-base, 7.2-jdk11-temurin-noble-base, 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
+Tags: 7.4.8-jdk17, 7.4-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17, 7-jdk17-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk17
 
-Tags: 7.2.2-jdk11-temurin-noble, 7.2-jdk11-temurin-noble, 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
+Tags: 7.4.8-jdk17-base, 7.4-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-base, 7-jdk17-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk17-base
 
-Tags: 7.2.2-jdk8-temurin-jammy-base, 7.2-jdk8-temurin-jammy-base
+Tags: 7.4.8-jdk21, 7.4-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21, 7-jdk21-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk21
 
-Tags: 7.2.2-jdk8-temurin-jammy, 7.2-jdk8-temurin-jammy
+Tags: 7.4.8-jdk21-base, 7.4-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-base, 7-jdk21-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk21-base
 
-Tags: 7.2.2-jdk8-temurin-noble-base, 7.2-jdk8-temurin-noble-base, 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
+Tags: 7.4.8-jdk25, 7.4-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk25
 
-Tags: 7.2.2-jdk8-temurin-noble, 7.2-jdk8-temurin-noble, 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
+Tags: 7.4.8-jdk25-base, 7.4-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-noble
-
-Tags: 7.3.3-jdk11-temurin-jammy-base, 7.3-jdk11-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-jammy-base
-
-Tags: 7.3.3-jdk11-temurin-jammy, 7.3-jdk11-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-jammy
-
-Tags: 7.3.3-jdk11-temurin-noble-base, 7.3-jdk11-temurin-noble-base, 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-noble-base
-
-Tags: 7.3.3-jdk11-temurin-noble, 7.3-jdk11-temurin-noble, 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-noble
-
-Tags: 7.3.3-jdk17-temurin-jammy-base, 7.3-jdk17-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-jammy-base
-
-Tags: 7.3.3-jdk17-temurin-jammy, 7.3-jdk17-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-jammy
-
-Tags: 7.3.3-jdk17-temurin-noble-base, 7.3-jdk17-temurin-noble-base, 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-noble-base
-
-Tags: 7.3.3-jdk17-temurin-noble, 7.3-jdk17-temurin-noble, 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-noble
-
-Tags: 7.3.3-jdk8-temurin-jammy-base, 7.3-jdk8-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-jammy-base
-
-Tags: 7.3.3-jdk8-temurin-jammy, 7.3-jdk8-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-jammy
-
-Tags: 7.3.3-jdk8-temurin-noble-base, 7.3-jdk8-temurin-noble-base, 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-noble-base
-
-Tags: 7.3.3-jdk8-temurin-noble, 7.3-jdk8-temurin-noble, 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-noble
-
-Tags: 7.4.8-jdk11-temurin-jammy-base, 7.4-jdk11-temurin-jammy-base, 7-jdk11-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-jammy-base
-
-Tags: 7.4.8-jdk11-temurin-jammy, 7.4-jdk11-temurin-jammy, 7-jdk11-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-jammy
-
-Tags: 7.4.8-jdk11-temurin-noble-base, 7.4-jdk11-temurin-noble-base, 7-jdk11-temurin-noble-base, 7.4.8-jdk11-base, 7.4-jdk11-base, 7-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-noble-base
-
-Tags: 7.4.8-jdk11-temurin-noble, 7.4-jdk11-temurin-noble, 7-jdk11-temurin-noble, 7.4.8-jdk11, 7.4-jdk11, 7-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-noble
-
-Tags: 7.4.8-jdk17-temurin-jammy-base, 7.4-jdk17-temurin-jammy-base, 7-jdk17-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-jammy-base
-
-Tags: 7.4.8-jdk17-temurin-jammy, 7.4-jdk17-temurin-jammy, 7-jdk17-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-jammy
-
-Tags: 7.4.8-jdk17-temurin-noble-base, 7.4-jdk17-temurin-noble-base, 7-jdk17-temurin-noble-base, 7.4.8-jdk17-base, 7.4-jdk17-base, 7-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-noble-base
-
-Tags: 7.4.8-jdk17-temurin-noble, 7.4-jdk17-temurin-noble, 7-jdk17-temurin-noble, 7.4.8-jdk17, 7.4-jdk17, 7-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-noble
-
-Tags: 7.4.8-jdk21-temurin-jammy-base, 7.4-jdk21-temurin-jammy-base, 7-jdk21-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-jammy-base
-
-Tags: 7.4.8-jdk21-temurin-jammy, 7.4-jdk21-temurin-jammy, 7-jdk21-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-jammy
-
-Tags: 7.4.8-jdk21-temurin-noble-base, 7.4-jdk21-temurin-noble-base, 7-jdk21-temurin-noble-base, 7.4.8-jdk21-base, 7.4-jdk21-base, 7-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-noble-base
-
-Tags: 7.4.8-jdk21-temurin-noble, 7.4-jdk21-temurin-noble, 7-jdk21-temurin-noble, 7.4.8-jdk21, 7.4-jdk21, 7-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-noble
-
-Tags: 7.4.8-jdk25-temurin-jammy-base, 7.4-jdk25-temurin-jammy-base, 7-jdk25-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-jammy-base
-
-Tags: 7.4.8-jdk25-temurin-jammy, 7.4-jdk25-temurin-jammy, 7-jdk25-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-jammy
-
-Tags: 7.4.8-jdk25-temurin-noble-base, 7.4-jdk25-temurin-noble-base, 7-jdk25-temurin-noble-base, 7.4.8-jdk25-base, 7.4-jdk25-base, 7-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-noble-base
-
-Tags: 7.4.8-jdk25-temurin-noble, 7.4-jdk25-temurin-noble, 7-jdk25-temurin-noble, 7.4.8-jdk25, 7.4-jdk25, 7-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-noble
-
-Tags: 7.4.8-jdk8-temurin-jammy-base, 7.4-jdk8-temurin-jammy-base, 7-jdk8-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-jammy-base
-
-Tags: 7.4.8-jdk8-temurin-jammy, 7.4-jdk8-temurin-jammy, 7-jdk8-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-jammy
-
-Tags: 7.4.8-jdk8-temurin-noble-base, 7.4-jdk8-temurin-noble-base, 7-jdk8-temurin-noble-base, 7.4.8-jdk8-base, 7.4-jdk8-base, 7-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-noble-base
-
-Tags: 7.4.8-jdk8-temurin-noble, 7.4-jdk8-temurin-noble, 7-jdk8-temurin-noble, 7.4.8-jdk8, 7.4-jdk8, 7-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk25-base

--- a/test/build-and-run.sh
+++ b/test/build-and-run.sh
@@ -17,7 +17,7 @@ command -v docker >/dev/null || { echo "docker is required" >&2; exit 1; }
 command -v curl >/dev/null   || { echo "curl is required" >&2; exit 1; }
 
 shopt -s nullglob
-image_dirs=( [0-9]*/*/temurin-*/Dockerfile )
+image_dirs=( [0-9]*/*/Dockerfile )
 image_dirs=( "${image_dirs[@]%/Dockerfile}" )
 (( ${#image_dirs[@]} > 0 )) || { echo "no images to test (run ./update.sh first?)" >&2; exit 1; }
 

--- a/test/lint.sh
+++ b/test/lint.sh
@@ -38,13 +38,11 @@ check_jq ".variants is a non-empty array of strings" \
 check_jq ".versions is a non-empty object" \
     '.versions | type == "object" and (to_entries | length > 0)'
 
-step "jq: every version has a semver-shaped patch and non-empty runtimes/os"
+step "jq: every version has a semver-shaped patch and non-empty runtimes"
 check_jq "each .version matches N.N.N" \
     '[.versions[] | .version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")] | all'
 check_jq "each .runtimes is a non-empty object" \
     '[.versions[] | .runtimes | type == "object" and (to_entries | length > 0)] | all'
-check_jq "each .os is a non-empty array of strings" \
-    '[.versions[] | .os | type == "array" and length > 0 and all(.[]; type == "string")] | all'
 check_jq "each runtimes[flavor] is a non-empty array of strings" \
     '[.versions[] | .runtimes | to_entries[] | .value | type == "array" and length > 0 and all(.[]; type == "string")] | all'
 
@@ -58,7 +56,7 @@ if ! command -v hadolint >/dev/null; then
     echo "SKIP: hadolint not installed"
 else
     shopt -s nullglob
-    dockerfiles=( [0-9]*/*/temurin-*/Dockerfile )
+    dockerfiles=( [0-9]*/*/Dockerfile )
     if (( ${#dockerfiles[@]} == 0 )); then
         echo "SKIP: no generated Dockerfiles present (run ./update.sh first)"
     else

--- a/test/regression.sh
+++ b/test/regression.sh
@@ -23,8 +23,8 @@ step() { printf '\n=== %s ===\n' "$1"; }
 
 # --- No unresolved template placeholders --------------------------------------
 step "generated Dockerfiles: envsubst placeholders all resolved"
-unresolved=$(grep -RHnE '\$\{(JAVA_VERSION|JDK_JRE|OS_VARIANT|LIGHTSTREAMER_VERSION)\}' \
-    [0-9]*/*/temurin-*/Dockerfile 2>/dev/null || true)
+unresolved=$(grep -RHnE '\$\{(JAVA_VERSION|FLAVOR|LIGHTSTREAMER_VERSION|LEGACY_PATCH)\}' \
+    [0-9]*/*/Dockerfile 2>/dev/null || true)
 if [[ -n "$unresolved" ]]; then
     echo "FAIL: unresolved template placeholders:"
     echo "$unresolved"

--- a/update.sh
+++ b/update.sh
@@ -10,8 +10,8 @@ command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
-# Explode the manifest into one "mm patch flavor java os variant" line per
-# (runtime × java × os × variant) combination. The Cartesian product is driven
+# Explode the manifest into one "mm patch flavor java variant" line per
+# (runtime × java × variant) combination. The Cartesian product is driven
 # entirely by versions.json — no cross-product code here.
 jq -r '
   .variants[] as $var |
@@ -19,11 +19,10 @@ jq -r '
   .key as $mm | .value.version as $patch |
   (.value.runtimes | to_entries[]) as $flav |
   $flav.value[] as $java |
-  .value.os[] as $os |
-  "\($mm) \($patch) \($flav.key) \($java) \($os) \($var)"
+  "\($mm) \($patch) \($flav.key) \($java) \($var)"
 ' versions.json \
-| while read -r APP_VERSION LIGHTSTREAMER_VERSION FLAVOR JAVA_VERSION OS_VARIANT VARIANT; do
-    export APP_VERSION LIGHTSTREAMER_VERSION FLAVOR JAVA_VERSION OS_VARIANT
+| while read -r APP_VERSION LIGHTSTREAMER_VERSION FLAVOR JAVA_VERSION VARIANT; do
+    export APP_VERSION LIGHTSTREAMER_VERSION FLAVOR JAVA_VERSION
 
     # Legacy patch: Lightstreamer <7.2 had a hard-coded /usr/jdk1.8.0 path in
     # bin/unix-like/LS.sh; rewrite it to $JAVA_HOME so the launch script uses
@@ -37,7 +36,7 @@ jq -r '
 
     # Full variant: <combo>/            Base variant: <combo>-base/
     # (DOI convention: canonical variant has no suffix, others do.)
-    combo="${APP_VERSION}/${FLAVOR}${JAVA_VERSION}/temurin-${OS_VARIANT}"
+    combo="${APP_VERSION}/${FLAVOR}${JAVA_VERSION}"
     if [[ "$VARIANT" == "full" ]]; then
         target_dir="${tmp}/${combo}"
         template="Dockerfile.template"
@@ -47,7 +46,7 @@ jq -r '
     fi
     mkdir -p "$target_dir"
 
-    envsubst '${JAVA_VERSION} ${FLAVOR} ${OS_VARIANT} ${LIGHTSTREAMER_VERSION} ${LEGACY_PATCH}' \
+    envsubst '${JAVA_VERSION} ${FLAVOR} ${LIGHTSTREAMER_VERSION} ${LEGACY_PATCH}' \
         < "$template" > "${target_dir}/Dockerfile"
 
     echo "Generated: ${target_dir#"$tmp/"}/Dockerfile (Lightstreamer ${LIGHTSTREAMER_VERSION}, ${VARIANT})"

--- a/versions.json
+++ b/versions.json
@@ -5,51 +5,43 @@
       "version": "6.0.3",
       "runtimes": {
         "jdk": ["8"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "6.1": {
       "version": "6.1.0",
       "runtimes": {
         "jdk": ["8"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "7.0": {
       "version": "7.0.3",
       "runtimes": {
         "jdk": ["8", "11"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "7.1": {
       "version": "7.1.3",
       "runtimes": {
         "jdk": ["8", "11"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "7.2": {
       "version": "7.2.2",
       "runtimes": {
         "jdk": ["8", "11"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "7.3": {
       "version": "7.3.3",
       "runtimes": {
         "jdk": ["8", "11", "17"]
-      },
-      "os": ["jammy", "noble"]
+      }
     },
     "7.4": {
       "version": "7.4.8",
       "runtimes": {
         "jdk": ["8", "11", "17", "21", "25"]
-      },
-      "os": ["jammy", "noble"]
+      }
     }
   }
 }
-


### PR DESCRIPTION
# Complete the OS-variant removal refactor

## What

Restores the pieces of the OS-variant removal refactor that were dropped from the earlier merge: the generator, the update script and the tests still contain OS-related code that no longer matches the on-disk layout.

## Why

Without these fixes `./generate-stackbrew-library.sh` on `master` produces an empty manifest, and `./test/lint.sh` skips hadolint entirely.

## Impact on published tags

Compared to the manifest currently live on [`hub.docker.com/_/lightstreamer`](https://hub.docker.com/_/lightstreamer):

- **All 83 published tags preserved unchanged.**
- **103 new tags** added for the new `-base` edition and backwards-compat mirrors.
- **Zero tags dropped.**

## Testing

- `./test/lint.sh` — pass
- `./test/regression.sh` — pass
- `bashbrew list --build-order --uniq lightstreamer` — 32 entries

## Follow-up

Once merged, submit the DOI PR (`lightstreamer: add -base variant`).

